### PR TITLE
remove queries from rust binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,6 @@
 /build/
 /examples/qtdeclarative
 /node_modules/
-/queries/highlights-javascript.scm
-/queries/highlights-typescript.scm
 /target/
 
 # Workaround for https://github.com/tree-sitter/tree-sitter/issues/730

--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,8 @@ help:
 
 .PHONY: generate
 generate:
-	$(MAKE) queries/highlights-javascript.scm queries/highlights-typescript.scm
 	$(MAKE) src/typescript-scanner.h
 	$(TREE_SITTER) generate
-
-# create symlinks out of sub packages so cargo can pick them up
-queries/highlights-javascript.scm: node_modules/tree-sitter-javascript/queries/highlights.scm
-	ln -sf ../$< $@
-queries/highlights-typescript.scm: node_modules/tree-sitter-typescript/queries/highlights.scm
-	ln -sf ../$< $@
 
 src/typescript-scanner.h: \
  node_modules/tree-sitter-typescript/common/scanner.h \
@@ -41,8 +34,6 @@ src/typescript-scanner.h: \
 clean:
 	$(RM) -R build target
 	$(RM) \
-		queries/highlights-javascript.scm \
-		queries/highlights-typescript.scm \
 		src/grammar.json \
 		src/node-types.json \
 		src/parser.c \

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -35,13 +35,9 @@ pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 
-pub const HIGHLIGHTS_QUERY: &'static str = concat!(
-    include_str!("../../queries/highlights-javascript.scm"),
-    include_str!("../../queries/highlights-typescript.scm"),
-    include_str!("../../queries/highlights.scm"),
-);
+// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
 // pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
-pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
+// pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]


### PR DESCRIPTION
This basically backs out 768cd53258d. I don't think these queries are used in practice, and symlinks can cause random problems on Windows.

#12