### PR TITLE
update deps, regenerate, & migrate to tree-sitter.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,27 +49,5 @@
     "tree-sitter-javascript": "^0.23.0",
     "tree-sitter-typescript": "^0.23.0",
     "prebuildify": "^6.0.1"
-  },
-  "tree-sitter": [
-    {
-      "scope": "source.qml",
-      "file-types": [
-        "qml"
-      ],
-      "highlights": [
-        "node_modules/tree-sitter-javascript/queries/highlights.scm",
-        "node_modules/tree-sitter-typescript/queries/highlights.scm",
-        "queries/highlights.scm"
-      ],
-      "locals": [
-        "queries/locals.scm",
-        "node_modules/tree-sitter-typescript/queries/locals.scm",
-        "node_modules/tree-sitter-javascript/queries/locals.scm"
-      ],
-      "tags": [
-        "node_modules/tree-sitter-typescript/queries/tags.scm",
-        "node_modules/tree-sitter-javascript/queries/tags.scm"
-      ]
-    }
-  ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   },
   "homepage": "https://github.com/yuja/tree-sitter-qmljs#readme",
   "dependencies": {
-    "node-addon-api": "^7.1.0",
-    "node-gyp-build": "^4.8.0"
+    "node-addon-api": "^8.2.1",
+    "node-gyp-build": "^4.8.2"
   },
   "peerDependencies": {
     "tree-sitter": "^0.21.0"
@@ -45,10 +45,10 @@
     }
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.22.6",
-    "tree-sitter-javascript": "^0.21.4",
-    "tree-sitter-typescript": "^0.21.2",
-    "prebuildify": "^6.0.0"
+    "tree-sitter-cli": "^0.24.3",
+    "tree-sitter-javascript": "^0.23.0",
+    "tree-sitter-typescript": "^0.23.0",
+    "prebuildify": "^6.0.1"
   },
   "tree-sitter": [
     {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,15 +1,7 @@
 {
-  "0": "t",
-  "1": "y",
-  "2": "p",
-  "3": "e",
-  "4": "s",
-  "5": "c",
-  "6": "r",
-  "7": "i",
-  "8": "p",
-  "9": "t",
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
   "name": "qmljs",
+  "inherits": "typescript",
   "word": "identifier",
   "rules": {
     "program": {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3316,256 +3316,6 @@
     }
   },
   {
-    "type": "jsx_attribute",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "jsx_element",
-          "named": true
-        },
-        {
-          "type": "jsx_expression",
-          "named": true
-        },
-        {
-          "type": "jsx_namespace_name",
-          "named": true
-        },
-        {
-          "type": "jsx_self_closing_element",
-          "named": true
-        },
-        {
-          "type": "property_identifier",
-          "named": true
-        },
-        {
-          "type": "string",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "jsx_closing_element",
-    "named": true,
-    "fields": {
-      "name": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "jsx_namespace_name",
-            "named": true
-          },
-          {
-            "type": "member_expression",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "jsx_element",
-    "named": true,
-    "fields": {
-      "close_tag": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "jsx_closing_element",
-            "named": true
-          }
-        ]
-      },
-      "open_tag": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "jsx_opening_element",
-            "named": true
-          }
-        ]
-      }
-    },
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "html_character_reference",
-          "named": true
-        },
-        {
-          "type": "jsx_element",
-          "named": true
-        },
-        {
-          "type": "jsx_expression",
-          "named": true
-        },
-        {
-          "type": "jsx_self_closing_element",
-          "named": true
-        },
-        {
-          "type": "jsx_text",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "jsx_expression",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "expression",
-          "named": true
-        },
-        {
-          "type": "sequence_expression",
-          "named": true
-        },
-        {
-          "type": "spread_element",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "jsx_namespace_name",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "jsx_opening_element",
-    "named": true,
-    "fields": {
-      "attribute": {
-        "multiple": true,
-        "required": false,
-        "types": [
-          {
-            "type": "jsx_attribute",
-            "named": true
-          },
-          {
-            "type": "jsx_expression",
-            "named": true
-          }
-        ]
-      },
-      "name": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "jsx_namespace_name",
-            "named": true
-          },
-          {
-            "type": "member_expression",
-            "named": true
-          }
-        ]
-      },
-      "type_arguments": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "type_arguments",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "jsx_self_closing_element",
-    "named": true,
-    "fields": {
-      "attribute": {
-        "multiple": true,
-        "required": false,
-        "types": [
-          {
-            "type": "jsx_attribute",
-            "named": true
-          },
-          {
-            "type": "jsx_expression",
-            "named": true
-          }
-        ]
-      },
-      "name": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "jsx_namespace_name",
-            "named": true
-          },
-          {
-            "type": "member_expression",
-            "named": true
-          }
-        ]
-      },
-      "type_arguments": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "type_arguments",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "jsx_text",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "labeled_statement",
     "named": true,
     "fields": {
@@ -4539,6 +4289,7 @@
   {
     "type": "program",
     "named": true,
+    "root": true,
     "fields": {
       "root": {
         "multiple": false,
@@ -4972,10 +4723,6 @@
       "types": [
         {
           "type": "escape_sequence",
-          "named": true
-        },
-        {
-          "type": "html_character_reference",
           "named": true
         },
         {
@@ -6427,10 +6174,6 @@
     "named": false
   },
   {
-    "type": "/>",
-    "named": false
-  },
-  {
     "type": ":",
     "named": false
   },
@@ -6440,10 +6183,6 @@
   },
   {
     "type": "<",
-    "named": false
-  },
-  {
-    "type": "</",
     "named": false
   },
   {
@@ -6684,10 +6423,6 @@
   },
   {
     "type": "hash_bang_line",
-    "named": true
-  },
-  {
-    "type": "html_character_reference",
     "named": true
   },
   {

--- a/src/tree_sitter/alloc.h
+++ b/src/tree_sitter/alloc.h
@@ -12,10 +12,10 @@ extern "C" {
 // Allow clients to override allocation functions
 #ifdef TREE_SITTER_REUSE_ALLOCATOR
 
-extern void *(*ts_current_malloc)(size_t);
-extern void *(*ts_current_calloc)(size_t, size_t);
-extern void *(*ts_current_realloc)(void *, size_t);
-extern void (*ts_current_free)(void *);
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
 
 #ifndef ts_malloc
 #define ts_malloc  ts_current_malloc

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -47,6 +47,7 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,48 @@
+{
+  "grammars": [
+    {
+      "name": "qmljs",
+      "camelcase": "Qmljs",
+      "scope": "source.qml",
+      "path": ".",
+      "file-types": [
+        "qml"
+      ],
+      "highlights": [
+        "node_modules/tree-sitter-javascript/queries/highlights.scm",
+        "node_modules/tree-sitter-typescript/queries/highlights.scm",
+        "queries/highlights.scm"
+      ],
+      "locals": [
+        "queries/locals.scm",
+        "node_modules/tree-sitter-typescript/queries/locals.scm",
+        "node_modules/tree-sitter-javascript/queries/locals.scm"
+      ],
+      "tags": [
+        "node_modules/tree-sitter-typescript/queries/tags.scm",
+        "node_modules/tree-sitter-javascript/queries/tags.scm"
+      ]
+    }
+  ],
+  "metadata": {
+    "version": "0.1.2",
+    "license": "MIT",
+    "description": "QML grammar for the tree-sitter parsing library",
+    "authors": [
+      {
+        "name": "Yuya Nishihara"
+      }
+    ],
+    "links": {
+      "repository": "git+https://github.com/yuja/tree-sitter-qmljs.git"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}


### PR DESCRIPTION
The CLI version used to generate the grammar was bugged when it came to the inherits field - this bug, which was remedied a while ago, causes a panic now on the latest master, so I'm putting this PR up to fix it and bump the dependencies. We also now use a dedicated config file instead of a tree-sitter section in package.json (see the docs for more info) so I migrated that for you as well. Thanks!