### PR TITLE
Update Rust bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,14 @@
 name = "tree-sitter-qmljs"
 description = "QML grammar for the tree-sitter parsing library"
 version = "0.2.0"
-keywords = ["incremental", "parsing", "qml"]
-categories = ["parsing", "text-editors"]
-repository = "https://github.com/yuja/tree-sitter-qmljs"
-edition = "2021"
+authors = ["Yuya Nishihara"]
 license = "MIT"
+readme = "README.md"
+keywords = ["incremental", "parsing", "tree-sitter", "qmljs"]
+categories = ["parser-implementations", "parsing", "text-editors"]
+repository = "git+https://github.com/yuja/tree-sitter-qmljs.git"
+edition = "2021"
+autoexamples = false
 
 build = "bindings/rust/build.rs"
 include = [
@@ -14,13 +17,18 @@ include = [
   "grammar.js",
   "queries/*",
   "src/*",
+  "tree-sitter.json",
+  "/LICENSE",
 ]
 
 [lib]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.24.0"
+tree-sitter-language = "0.1"
 
 [build-dependencies]
-cc = "1.0.96"
+cc = "1.2"
+
+[dev-dependencies]
+tree-sitter = "0.25.9"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,11 +2,7 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.include(&src_dir);
-    c_config
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-unused-but-set-variable")
-        .flag_if_supported("-Wno-trigraphs");
+    c_config.std("c11").include(src_dir);
 
     #[cfg(target_env = "msvc")]
     c_config.flag("-utf-8");
@@ -16,12 +12,10 @@ fn main() {
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
     let scanner_path = src_dir.join("scanner.c");
-    c_config.file(&scanner_path);
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    println!(
-        "cargo:rerun-if-changed={}",
-        src_dir.join("typescript-scanner.h").to_str().unwrap()
-    );
+    if scanner_path.exists() {
+        c_config.file(&scanner_path);
+        println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    }
 
-    c_config.compile("parser-scanner");
+    c_config.compile("tree-sitter-qmljs");
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,44 +1,53 @@
-//! This crate provides QML language support for the [tree-sitter][] parsing library.
+//! This crate provides Qmljs language support for the [tree-sitter] parsing library.
 //!
-//! Typically, you will use the [language][language func] function to add this language to a
-//! tree-sitter [Parser][], and then use the parser to parse some code:
+//! Typically, you will use the [`LANGUAGE`] constant to add this language to a
+//! tree-sitter [`Parser`], and then use the parser to parse some code:
 //!
 //! ```
-//! let code = "";
+//! let code = r#"
+//! import QtQml
+//! 
+//! @Foo {}
+//! @Bar {}
+//! @Baz.Nested.Name {}
+//! QtObject {
+//!    @Foo {}
+//!    @Bar {}
+//!    OtObject {}
+//! }
+//! "#;
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(&tree_sitter_qmljs::language()).expect("Error loading QML grammar");
+//! let language = tree_sitter_qmljs::LANGUAGE;
+//! parser
+//!     .set_language(&language.into())
+//!     .expect("Error loading Qmljs parser");
 //! let tree = parser.parse(code, None).unwrap();
+//! assert!(!tree.root_node().has_error());
 //! ```
 //!
-//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-//! [language func]: fn.language.html
-//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [`Parser`]: https://docs.rs/tree-sitter/0.25.9/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
+use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_qmljs() -> Language;
+    fn tree_sitter_qmljs() -> *const ();
 }
 
-/// Get the tree-sitter [Language][] for this grammar.
+/// The tree-sitter [`LanguageFn`] for this grammar.
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_qmljs) };
+
+/// The content of the [`node-types.json`] file for this grammar.
 ///
-/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
-    unsafe { tree_sitter_qmljs() }
-}
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers/6-static-node-types
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
-/// The content of the [`node-types.json`][] file for this grammar.
-///
-/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
-pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+// NOTE: uncomment these to include any queries that this grammar contains:
 
-// Uncomment these to include any queries that this grammar contains
-
-// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
-// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
-// pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
-// pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
+pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+// pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
+pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
+// pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {
@@ -46,7 +55,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(&super::language())
-            .expect("Error loading QML language");
+            .set_language(&super::LANGUAGE.into())
+            .expect("Error loading Qmljs parser");
     }
 }


### PR DESCRIPTION
The default Rust bindings for grammars have evolved in recent versions of tree-sitter. This updates the bindings of this parser to match that. (Obtained by removing the bindings, running `tree-sitter init -u`, and making small corrections to the `lib.rs` file).