### PR TITLE
Use actual version of installed tree-sitter-typescript package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ generate:
 src/typescript-scanner.h: \
  node_modules/tree-sitter-typescript/common/scanner.h \
  node_modules/tree-sitter-typescript/LICENSE \
- package.json
+ node_modules/tree-sitter-typescript/package.json
 	( \
 		echo '/*'; \
 		echo 'Source:'; \
-		$(JQ) -r '.devDependencies["tree-sitter-typescript"]' package.json; \
+		$(JQ) -r '.version' node_modules/tree-sitter-typescript/package.json; \
 		echo; \
 		cat node_modules/tree-sitter-typescript/LICENSE; \
 		echo '*/'; \


### PR DESCRIPTION
Something I noticed while setting up my dev environment:

The generated file contained version range string instead of an actual version.

Before:
```
Source:
^0.23.2
```

After:
```
Source:
0.23.2
```