### PR TITLE
Draft: Remove tst_scrollbar.qml from the blacklist

### DIFF
--- a/examples/known-failures.txt
+++ b/examples/known-failures.txt
@@ -48,5 +48,4 @@ qtdeclarative/tests/auto/qmlls/utils/data/qualifiedModule.qml
 qtdeclarative/tests/auto/qmlls/utils/data/renaming/UnrelatedFile.qml
 qtdeclarative/tests/auto/qtquickview/statuslistener/android/qml/Invalid.qml
 qtdeclarative/tests/auto/quick/qquickloader/data/InvalidSourceComponent.qml
-qtdeclarative/tests/auto/quickcontrols/controls/data/tst_scrollbar.qml
 qtdeclarative/tests/manual/qmllsformatter/test.qml


### PR DESCRIPTION
Put this patch on hold until Qt fixes their broken syntax in the test
file upstream first.

Of course, it would require a "bump reference grammar" commit too.

Closes: #27
Requires: https://codereview.qt-project.org/c/qt/qtdeclarative/+/738118
See also: QTBUG-146961