### PR TITLE
fix: include external scanner in Python binding build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
             sources=[
                 "bindings/python/tree_sitter_qmljs/binding.c",
                 "src/parser.c",
-                # NOTE: if your language uses an external scanner, add it here.
+                "src/scanner.c",
             ],
             extra_compile_args=[
                 "-std=c11",


### PR DESCRIPTION
## Summary

`setup.py`'s `Extension` only lists `src/parser.c` in `sources`, but this grammar defines an external scanner (`src/scanner.c`, referenced from `src/parser.c`). Without it, the compiled Python extension fails to load:

```
ImportError: dlopen(.../tree_sitter_qmljs/_binding.abi3.so, 0x0002): symbol not found in flat namespace '_tree_sitter_qmljs_external_scanner_create'
```

This mirrors the same fix already applied to the Node.js binding's `binding.gyp` in a2bce2a — that fix just never made it into `setup.py`.

## Fix

Add `src/scanner.c` to the `Extension(sources=[...])` list.

## Test plan

- `pip install .` (or `pip install git+<this-branch>`) now builds and loads successfully.
- Verified locally: parsed a small QML snippet (`import QtQuick 2.15; Item { id: root; property int foo: 5; function bar() {...}; Text { text: root.foo } }`) via `tree_sitter_qmljs.language()` + `tree_sitter.Parser` — before the fix, `import tree_sitter_qmljs` raises the `ImportError` above; after the fix, the parser loads and produces the expected `ui_import` / `ui_object_definition` / `ui_binding` / `function_declaration` tree.

Made with [Cursor](https://cursor.com)